### PR TITLE
Enable PMU reset by long pressing (>16s) the power button.

### DIFF
--- a/blobs/sys_config_pine64-pinebook.fex
+++ b/blobs/sys_config_pine64-pinebook.fex
@@ -1440,6 +1440,7 @@ pmu_powkey_off_func        = 0
 pmu_powkey_off_en          = 1
 pmu_powkey_long_time       = 1500
 pmu_powkey_on_time         = 1000
+pmu_reset                  = 1
 power_start                = 0
 
 ;--------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The AXP803 PMIC offers a functionality via register 8FH to trigger a reset of itself by pressing the power button for more than 16s, this could help to get out of fault conditions.